### PR TITLE
Accurate Hammer Units -> Stud Conversion

### DIFF
--- a/VMFImporter/init.server.lua
+++ b/VMFImporter/init.server.lua
@@ -37,7 +37,7 @@ local importVmf = toolbar:CreateButton(
 	"Import VMF [BETA]"
 )
 
-local VMF_UNITS_PER_STUD = 10
+local VMF_UNITS_PER_STUD = 0.28 / .01905
 local ROUND_VERTEX_EPSILON = 0.01 -- Edges shorter than this are considered degenerate.
 local MIN_EDGE_LENGTH_EPSILON = 0.1 -- Vertices within this many units of an integer value will be rounded to an integer value.
 


### PR DESCRIPTION
According to the ROBLOX world panel or whatever in game settings, a stud is exactly 0.28 meters.
According to the Valve Developer Community (https://developer.valvesoftware.com/wiki/Dimensions), 1 foot is 16 units. With some simple math, it can be determined that a unit is exactly 0.01905 meters large.

This pull request changes the VMF_UNITS_PER_STUD constant to conform to these measurements
I haven't really played around with it too much for maps so no clue if its accurate to player scale, further testing required (probably shouldn't merge)