### PR TITLE
[Fix biggest UX painpoint]: Made QuickInsert be able to insert assets outside of inventory, as well as fixed insert failing for sounds and images.

### DIFF
--- a/QuickInsert/Plugin/init.server.lua
+++ b/QuickInsert/Plugin/init.server.lua
@@ -111,6 +111,15 @@ local function isAccessoryAsset(assetType: Enum.AssetType)
 	return assetType.Name:sub(-9) == "Accessory"
 end
 
+
+local function isImageAsset(assetType: Enum.AssetType)
+	return assetType.Name:sub(-5) == "Image"
+end
+
+local function isAudioAsset(assetType: Enum.AssetType)
+	return assetType.Name:sub(-5) == "Audio"
+end
+
 local function onFocusLost(enterPressed)
 	if enterPressed then
 		local success, errorMsg = pcall(function ()
@@ -127,10 +136,11 @@ local function onFocusLost(enterPressed)
 			local isHead = isHeadAsset(assetType)
 			local isAccessory = isAccessoryAsset(assetType)
 			
-			local success, errorMsg = pcall(function ()
-				local asset: Instance
-				
+			local success, errorMsg = pcall(function()
+				local everything = {}
+
 				if isHead or isAccessory then
+					local asset: Instance
 					local hDesc = Instance.new("HumanoidDescription")
 					
 					if isHead then
@@ -157,7 +167,7 @@ local function onFocusLost(enterPressed)
 						end
 					end
 					
-					for i, desc in asset:GetDescendants() do
+					for _, desc in asset:GetDescendants() do
 						if desc:IsA("Vector3Value") then
 							local parent = desc.Parent
 
@@ -170,13 +180,27 @@ local function onFocusLost(enterPressed)
 							end
 						end
 					end
+
+					everything = asset:GetChildren()
+				elseif isImageAsset(assetType) then
+					local decal = Instance.new("Decal")
+
+					decal.Name = tostring(info.Name)
+					decal.Texture = "rbxassetid://"..tostring(assetId)
+
+					table.insert(everything, decal)
+				elseif isAudioAsset(assetType) then
+					local sound = Instance.new("Sound")
+
+					sound.Name = tostring(info.Name)
+					sound.SoundId = "rbxassetid://"..tostring(assetId)
+
+					table.insert(everything, sound)
 				else
-					asset = InsertService:LoadAsset(assetId)
+					everything = game:GetObjects("rbxassetid://"..tostring(assetId))
 				end
 
-				local everything = asset:GetChildren()
-
-				for i, item in everything do
+				for _, item in everything do
 					item.Parent = workspace
 				end
 

--- a/QuickInsert/Plugin/init.server.lua
+++ b/QuickInsert/Plugin/init.server.lua
@@ -137,7 +137,7 @@ local function onFocusLost(enterPressed)
 			local isAccessory = isAccessoryAsset(assetType)
 			
 			local success, errorMsg = pcall(function()
-				local everything = {}
+				local everything: {Instance} = {}
 
 				if isHead or isAccessory then
 					local asset: Instance


### PR DESCRIPTION
Currently the QuickInsert plugin is not very usable due to a few things that cripple it's usage. These are:

- The plugin is not able to insert assets outside of your inventory. If you wan't to insert an assets from the website you would have to first buy it in your inventory. In which case you might as well just use the toolbox to insert that asset.
- It cannot inserts sounds at all because sounds are not rbxm assets.
- It cannot inserts images at all because images are not rbxm assets.

This pull request fixes all of the above and makes it a breeze to insert assets.